### PR TITLE
Feature/double speck reader

### DIFF
--- a/Source/IO/CMakeLists.txt
+++ b/Source/IO/CMakeLists.txt
@@ -15,6 +15,7 @@ set (IO_HEADERFILES
     KTDPTReader.hh
     KTSpecReader.hh
     KTSpecProcessor.hh
+    KTSpeckProcessor.hh
     KTLongSpecProcessor.hh
     KTRFSlewtoVec.hh
     #KTMultiFileJSONReader.hh
@@ -34,6 +35,7 @@ set (IO_SOURCEFILES
     KTDPTReader.cc
     KTSpecReader.cc
     KTSpecProcessor.cc
+    KTSpeckProcessor.cc
     KTLongSpecProcessor.cc
     KTRFSlewtoVec.cc
     #KTMultiFileJSONReader.cc

--- a/Source/IO/KTLongSpecProcessor.cc
+++ b/Source/IO/KTLongSpecProcessor.cc
@@ -14,7 +14,7 @@ using namespace std;
 namespace Katydid
 {
     static Nymph::KTCommandLineOption< string > sFilenameCLO("Long Spec Processor",
-    "Spec filename to open", "spec-file", 's');
+    "Spec filename to open", "long-spec-file", 'l');
 
     KTLOGGER(speclog, "KTLongSpecProcessor");
 

--- a/Source/IO/KTLongSpecProcessor.cc
+++ b/Source/IO/KTLongSpecProcessor.cc
@@ -159,7 +159,7 @@ namespace Katydid
             char specFlagA, specFlagB, specFlagC, specFlagD;
 
             bool packetDrop =  false;
-            int pkt_num [fNSpectra];
+            vector<int> pkt_num(fNSpectra);
 
             for(int i = 0; i < fNSpectra; i++) //loop over # of spectra to be output
             {
@@ -260,10 +260,10 @@ namespace Katydid
                 else sliceHeader.SetIsTrapOff(0);
 
                 //assume for now that all runs start at time t=0
-                sliceHeader.SetTimeInRun(i*fFreqBinsPerPkt*fPacketsPerSpectrum*fROACH_FFT_Avg*fSpecTimeAvg/fFreqMax);
+                sliceHeader.SetTimeInRun(i/fFreqMax*fFreqBinsPerPkt*fPacketsPerSpectrum*fROACH_FFT_Avg*fSpecTimeAvg);
 
                 //assume for now that there is 1 acq per run, all runs start at t=0
-                sliceHeader.SetTimeInAcq(i*fFreqBinsPerPkt*fPacketsPerSpectrum*fROACH_FFT_Avg*fSpecTimeAvg/fFreqMax);
+                sliceHeader.SetTimeInAcq(i/fFreqMax*fFreqBinsPerPkt*fPacketsPerSpectrum*fROACH_FFT_Avg*fSpecTimeAvg);
 
                 sliceHeader.SetStartRecordNumber(0);
 

--- a/Source/IO/KTLongSpecProcessor.cc
+++ b/Source/IO/KTLongSpecProcessor.cc
@@ -197,10 +197,12 @@ namespace Katydid
 
                 //Check if sequential spectra have correct packet numbers
                 pkt_num[i] = bitset<8>(memblock[1]).to_ulong()*pow(2,16)+bitset<8>(memblock[2]).to_ulong()*pow(2,8)+bitset<8>(memblock[3]).to_ulong();
-                pkt_num[i] = pkt_num[i] % 171872;
                 KTINFO(speclog, "Decimal pkt_num = " << pkt_num[i]);
-                if (i>0 && pkt_num[i]-pkt_num[i-1]!=fPacketsPerSpectrum*fSpecTimeAvg){
-                    KTWARN(speclog, "WARNING: " << pkt_num[i]-pkt_num[i-1] << " packets dropped!");
+                if (i>0)
+                {
+                    int adjusted_pkt_num = (pkt_num[i-1] + fPacketsPerSpectrum*fSpecTimeAvg ) % 1048576; //2^20, max packet number for 2^12 bitcode
+                    if(pkt_num[i] - adjusted_pkt_num != 0)
+                        KTWARN(speclog, "WARNING: " << pkt_num[i]-adjusted_pkt_num << " packets dropped!");
                 }
 
                 specFlagA = memblock[24];
@@ -208,8 +210,8 @@ namespace Katydid
                 specFlagC = memblock[16472];
                 specFlagD = memblock[24696];
 
-                if ((bitset<8>(specFlagA) != 128 || bitset<8>(specFlagB) != 160
-                || bitset<8>(specFlagC) != 192 || bitset<8>(specFlagD) != 224) & fPacketsPerSpectrum == 4)
+                if ((fPacketsPerSpectrum == 4) && (bitset<8>(specFlagA) != 128 || bitset<8>(specFlagB) != 160
+                || bitset<8>(specFlagC) != 192 || bitset<8>(specFlagD) != 224))
                 {
                   KTWARN(speclog, "WARNING: Packet dropped from spectrum # " << i << "!!");
                   packetDrop = true;

--- a/Source/IO/KTRFSlewtoVec.cc
+++ b/Source/IO/KTRFSlewtoVec.cc
@@ -13,6 +13,7 @@
 #include "KTLogger.hh"
 #include "KTSliceHeader.hh"
 #include "KTPowerSpectrumData.hh"
+#include <fstream>
 #include <numeric>
 
 namespace Katydid

--- a/Source/IO/KTSpecProcessor.cc
+++ b/Source/IO/KTSpecProcessor.cc
@@ -1,4 +1,4 @@
-#include<iostream>
+#include <iostream>
 #include <fstream>
 #include "KTSpecProcessor.hh"
 #include "KTCommandLineOption.hh"
@@ -13,8 +13,7 @@ using namespace std;
 
 namespace Katydid
 {
-    static Nymph::KTCommandLineOption< string > sFilenameCLO("Spec Processor",
-    "Spec filename to open", "spec-file", 's');
+    static Nymph::KTCommandLineOption< string > sFilenameCLO("Spec Processor", "Spec filename to open", "spec-file", 'c');
 
     KTLOGGER(speclog, "KTSpecProcessor");
 
@@ -24,11 +23,17 @@ namespace Katydid
             KTPrimaryProcessor(name),
             fProgressReportInterval(1),
             fFilenames(),
-            fFreqBins(4096),
+            fFreqBins(8192),
             fNSpectra(0),
+            fPacketIDOffset(9),
+            fPacketHeaderSize(32),
             fFreqMin(0.),
-            fFreqMax(1600000000),
-            fSpectraAvg(8),
+            fFreqMax(2400000000),
+            fBinTOff(342),          //the trap off signal frequency bin
+            fBinTOffPow(20),
+            fROACH_FFT_Avg(2),      //the number of sequential FFTs averaged on the DAQ before output to *.spec
+            fSpecFreqAvg(1),        //the number of freq bins to average (for improving SNR with nonzero df/dt)
+            fSpecs(),
             fDataSignal("ps", this),
             fSpecDoneSignal("spec-done", this)
     {
@@ -61,12 +66,17 @@ namespace Katydid
                     KTINFO(speclog, "Added file to spec processor: <" << fFilenames.back() << ">");
                 }
             }
+
             fNSpectra = node->get_value< unsigned >("spectra", fNSpectra);
+            fPacketIDOffset = node->get_value< unsigned >("packet-ID-offset", fPacketIDOffset);
             fPacketHeaderSize = node->get_value< unsigned >("header-bytes", fPacketHeaderSize);
-            fSpectraAvg = node->get_value< unsigned >("ROACH-spect-avg", fSpectraAvg);
-            fFreqBins = node->get_value< unsigned >("freq-bins", fFreqBins);
+            fROACH_FFT_Avg = node->get_value< unsigned >("ROACH-spect-avg", fROACH_FFT_Avg);
+            fFreqBins = node->get_value< unsigned >("freq-bins", fFreqBins); //total bins
             fFreqMin = node->get_value< double >("min-freq", fFreqMin);
             fFreqMax = node->get_value< double >("max-freq", fFreqMax);
+            fBinTOff = node->get_value< int >("TOff-bin", fBinTOff);
+            fBinTOffPow = node->get_value< int >("TOff-bin-pow", fBinTOffPow);
+            fSpecFreqAvg = node->get_value< unsigned >("freq-bin-avg", fSpecFreqAvg);
         }
 
         // Command-line settings
@@ -81,6 +91,14 @@ namespace Katydid
         return true;
     }
 
+    int KTSpecProcessor::PacketNumber(char *aBufferPointer)
+    {
+        int pkt_num = bitset<8>(uint8_t(*(aBufferPointer + fPacketIDOffset))).to_ulong() * pow(2,16);
+        pkt_num += bitset<8>(uint8_t(*(aBufferPointer + fPacketIDOffset + 1))).to_ulong() * pow(2,8);
+        pkt_num += bitset<8>(uint8_t(*(aBufferPointer + fPacketIDOffset + 2))).to_ulong();
+        return pkt_num;
+    }
+
     bool KTSpecProcessor::ProcessSpec()
     {
         if (fFilenames.size() == 0)
@@ -89,142 +107,184 @@ namespace Katydid
             return false;
         }
 
-        // open the file and load its contents into memblock
-        KTINFO(speclog, "Opening spec file <" << fFilenames[0] << ">");
-        streampos size;
-        unsigned char * memblock;
-
-        std::ifstream file(fFilenames[0].c_str(), ios::in|ios::binary|ios::ate);
-
-        if (file.is_open())
+        if (fFilenames.size() > 2)
         {
-            KTINFO(speclog, "Spec file <" << fFilenames[0] << "> opened");
-            unsigned char a;
-            //uint a; //spectra must be treated as unsigned 8-bit values (0-255)
-            int slice[fFreqBins]; //holder array for spectrum data
-            int position = 0; //variable for read position start
-            int blockSize = fPacketHeaderSize+fFreqBins; //add header length
-
-            //declare array of 1-byte chars to read from binary file
-            char memblock [blockSize];
-            char headerblock [fPacketHeaderSize]; //declare array to read header of 1st packet in file
-            
-            //The header of each packet is divided into 4 words of 64 bits (8 bytes) each.
-            //Information on the packet offset is located in the first 3 bits of the final word.
-            //The 0th bit of the last word should always be 1 to indicate freq-domain data.
-            //Bits 1 and 2 of the last word indicate which part of the spectrum a packet
-            //corresponds to. All trailing bits should be zero.
-
-            vector <KTPowerSpectrum*> newSpec(1);
-            int pkt_num [fNSpectra];
-
-            //loop over # of spectra to be read
-            for(int i = 0; i < fNSpectra; i++)
-            {
-                if (i == 0) KTINFO(speclog, "Preparing to read first spectrum");
-                position = i*(blockSize);
-                KTINFO(speclog, "position = " << position);
-                file.seekg (position, ios::beg); //set read pointer location
-                file.read (headerblock, fPacketHeaderSize); //read header first
-
-                //Check if sequential spectra have correct packet numbers
-                pkt_num[i] =bitset<8>(memblock[1]).to_ulong()*pow(2,16)+bitset<8>(memblock[2]).to_ulong()*pow(2,8)+bitset<8>(memblock[3]).to_ulong();
-                KTINFO(speclog, "Decimal pkt_num = " << pkt_num[i]);
-                if (i>0 && pkt_num[i]-pkt_num[i-1]!=1){
-                    KTWARN(speclog, "WARNING: " << pkt_num[i]-pkt_num[i-1] << " packets dropped!");
-                }
-
-                file.seekg (position, ios::beg); //set read pointer location
-                file.read (memblock, blockSize); //read 1 spectrum of data
-
-                for (int x = 0; x < fFreqBins; x++)
-                {
-                    a =  memblock[x+fPacketHeaderSize];
-                    slice[x] = a;
-                }
-
-                unsigned comp = 0;
-                //initialize an object of type KTPowerSpectrum with all 0
-                //values and 8192 Bins from 0 to 1600 MHz
-                Nymph::KTDataPtr data(new Nymph::KTData());
-
-                KTSliceHeader& sliceHeader = data->Of< KTSliceHeader >().SetNComponents(1);
-
-                sliceHeader.SetSliceNumber(i);
-
-                sliceHeader.SetPacketNumber(pkt_num[i]);
-
-                //slice size in bytes = # of bins (given 8-bit resolution)
-                sliceHeader.SetRawSliceSize(fFreqBins);
-
-                //no diff between 'raw' slice size, slice size
-                sliceHeader.SetSliceSize(fFreqBins);
-
-                //Nyquist frequency is 1/2 sampling rate
-                sliceHeader.SetSampleRate(2*fFreqMax);
-                KTINFO(speclog, "Frequency max = " << fFreqMax);
-
-                //slice length is 2x # of bins / 2x Nyquist freq, times averaged spectra
-                sliceHeader.SetSliceLength(fFreqBins*fSpectraAvg/fFreqMax);
-
-                //bin width = bandwidth/bins
-                sliceHeader.SetBinWidth(fFreqMax/fFreqBins);
-
-                //assume for now that all runs start at time t=0
-                sliceHeader.SetTimeInRun(i*fFreqBins*fSpectraAvg/fFreqMax);
-                KTDEBUG(speclog, "TimeInRun = "<<(i*fFreqBins*fSpectraAvg/fFreqMax));
-
-                //assume for now that there is 1 acq per run, all runs start at t=0
-                sliceHeader.SetTimeInAcq(i*fFreqBins*fSpectraAvg/fFreqMax);
-
-                sliceHeader.SetStartRecordNumber(0);
-
-                sliceHeader.SetStartSampleNumber(0);
-
-                sliceHeader.SetEndRecordNumber(0);
-
-                sliceHeader.SetEndSampleNumber(0);
-
-                sliceHeader.SetRecordSize(0);
-
-
-                newSpec[0] = new KTPowerSpectrum(slice, fFreqBins, fFreqMin, fFreqMax);
-                KTPowerSpectrumData& psData = data->Of< KTPowerSpectrumData >().SetNComponents(1);
-                psData.SetSpectrum(newSpec[0], comp);
-                psData.GetArray(comp)->GetAxis().SetBinsRange(fFreqMin, fFreqMax, fFreqBins);
-
-                if (i == 0)
-                {
-                	KTINFO(speclog, "Set first spectrum object")
-                	
-                	sliceHeader.SetIsNewAcquisition(1);
-                    KTINFO(speclog, "Set New Acquisition!");
-                    
-                    double min = psData.GetArray(comp)->GetAxis().GetRangeMin();
-                    KTINFO(speclog, "First spectrum min freq = " << min);
-
-                    double max = psData.GetArray(comp)->GetAxis().GetRangeMax();
-                    KTINFO(speclog, "First spectrum max freq = " << max);
-
-                    double width = psData.GetArray(comp)->GetAxis().GetBinWidth();
-                    KTINFO(speclog, "First spectrum bin width = " << width);
-                }
-				else sliceHeader.SetIsNewAcquisition(0);
-
-                if(i == fNSpectra -1)
-                {
-                    data->Of< Nymph::KTData >().SetLastData(true);
-                    KTINFO(speclog, "fLastData set to TRUE");
-                }
-
-                fDataSignal(data);
-                if (i == 0) KTINFO(speclog, "First spectrum data signal output");
-
-            }
-            fSpecDoneSignal();
-            KTINFO(speclog, "Spec-done signal output");
+            KTERROR(speclog, "More than 2 spec simultaneous files have been specified! We don't have that much bandwidth!");
+            return false;
         }
-        file.close();
+
+        //check if fSpecFreqAvg divides fFreqBins evenly
+        if(fFreqBins % fSpecFreqAvg != 0)
+            KTWARN(speclog, "freq-bin-avg does not divide freq-bins!");
+
+        const unsigned fEffectiveFreqBins = fFreqBins / fSpecFreqAvg;
+
+        const int nChannels = fFilenames.size();
+        //check if fFreqBins divides nChannels evenly
+        if(fEffectiveFreqBins % nChannels != 0)
+            KTWARN(speclog, "nChannels does not divide (effective) freq-bins!");
+
+        const int nBins = fFreqBins / nChannels; // number of frequency bins per channel
+        const int nPacketSize = fPacketHeaderSize + nBins; // could use reconfiguration (user config) if more general case wanted
+        KTDEBUG(speclog, "Packet Size: "<<nPacketSize);
+
+        // For file j, j*fBinOffsetPerFile is added to the bin numbers to files are not "on top of each other"
+        const unsigned fBinOffsetPerFile = fEffectiveFreqBins / nChannels;
+
+        // Open the .spec files
+        for(unsigned i = 0; i <fFilenames.size(); ++i)
+        {
+            KTINFO(speclog, "Opening spec file <" << fFilenames[i] << ">");
+            if(fFilenames[i].extension() != ".spec")
+                KTFATAL(speclog, fFilenames[i] <<" is not a .spec file!");
+
+            // open the file and load its full contents into memblock
+            fSpecs.emplace_back(fFilenames[i], nPacketSize);
+            if(!fSpecs[i].file.is_open())
+            {
+                KTFATAL(speclog, fFilenames[i] <<" is failed to open!");
+            }
+            else
+            {
+                KTINFO(speclog, "Spec file <" << fFilenames[i] << "> opened");
+            }
+        }
+
+        //spectra must be treated as unsigned 8-bit values (0-255)
+        int slice[fEffectiveFreqBins]; //holder array for spectrum data, set to all zeros
+        std::fill(slice, slice + fEffectiveFreqBins, 0);
+
+        vector <KTPowerSpectrum*> newSpec(1);
+        int pkt_num[fNSpectra];
+        unsigned binOffset;
+
+        //loop over # of spectra to be read
+        for(int i = 0; i < fNSpectra; ++i)
+        {
+
+            if (i == 0) KTINFO(speclog, "Preparing to read first spectrum");
+
+            for(unsigned j = 0; j < nChannels; ++j)
+            {
+                KTINFO(speclog, "Spec: "<<j<<" is at position: " << j * nPacketSize);
+                fSpecs[j].file.read(fSpecs[j].pointer, nPacketSize); //read full packet(s) into (respective) buffers
+            }
+
+            pkt_num[i] = PacketNumber(fSpecs[0].pointer);
+            KTINFO(speclog, "Decimal pkt_num = " << pkt_num[i]);
+
+            //Check if sequential spectra have correct packet numbers
+            if (i>0)
+            {
+                // Both fPacketsPerSpectrum and fSpecTimeAvg are forced to be 1, for now in speck_processor
+                int adjusted_pkt_num = (pkt_num[i-1] + 1) % 1048576; //2^20, max packet number for 2^12 bitcode
+                if(pkt_num[i] - adjusted_pkt_num != 0)
+                    KTWARN(speclog, "WARNING: " << pkt_num[i]-adjusted_pkt_num << " packets dropped!");
+            }
+            //Check if simultaneous spectra have correct packet numbers
+            if(nChannels == 2  && (pkt_num[i] != PacketNumber(fSpecs[1].pointer)))
+                KTFATAL(speclog, "You have packet shear between spectrogram  files! Incompatible files!");
+
+            std::fill(slice, slice + fEffectiveFreqBins, 0);
+
+            for(unsigned j = 0; j < nChannels; ++j)
+            { 
+                binOffset = j*fBinOffsetPerFile;
+                for(unsigned k = 0; k < nBins; ++k)
+                    slice[k/fSpecFreqAvg + binOffset] += fSpecs[j].buffer[fPacketHeaderSize + k];
+            }
+
+            unsigned comp = 0;
+            //initialize an object of type KTPowerSpectrum with all 0
+            //values and 8192 Bins from 0 to 1600 MHz
+            Nymph::KTDataPtr data(new Nymph::KTData());
+
+            KTSliceHeader& sliceHeader = data->Of< KTSliceHeader >().SetNComponents(1);
+
+            if (slice[fBinTOff] > fBinTOffPow)
+            {
+                sliceHeader.SetIsTrapOff(1);
+                //KTINFO(speclog, "Set trap off!");
+            }
+            else sliceHeader.SetIsTrapOff(0);
+
+            sliceHeader.SetSliceNumber(i);
+
+            sliceHeader.SetPacketNumber(pkt_num[i]);
+
+            //slice size in bytes = # of bins (given 8-bit resolution)
+            sliceHeader.SetRawSliceSize(fEffectiveFreqBins);
+
+            //no diff between 'raw' slice size, slice size
+            sliceHeader.SetSliceSize(fFreqBins);
+
+            //Nyquist frequency is 1/2 sampling rate
+            sliceHeader.SetSampleRate(2*fFreqMax);
+            KTINFO(speclog, "Frequency max = " << fFreqMax);
+
+            //slice length is 2x # of bins / 2x Nyquist freq, times averaged spectra
+            sliceHeader.SetSliceLength(fFreqBins*fROACH_FFT_Avg/fFreqMax);
+
+            //bin width = bandwidth/bins
+            sliceHeader.SetBinWidth(fFreqMax/fEffectiveFreqBins);
+
+            //assume for now that all runs start at time t=0
+            sliceHeader.SetTimeInRun(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
+            KTDEBUG(speclog, "TimeInRun = "<<(i*fFreqBins*fROACH_FFT_Avg/fFreqMax));
+
+            //assume for now that there is 1 acq per run, all runs start at t=0
+            sliceHeader.SetTimeInAcq(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
+
+            sliceHeader.SetStartRecordNumber(0);
+
+            sliceHeader.SetStartSampleNumber(0);
+
+            sliceHeader.SetEndRecordNumber(0);
+
+            sliceHeader.SetEndSampleNumber(0);
+
+            sliceHeader.SetRecordSize(0);
+
+
+            newSpec[0] = new KTPowerSpectrum(slice, fEffectiveFreqBins, fFreqMin, fFreqMax);
+            KTPowerSpectrumData& psData = data->Of< KTPowerSpectrumData >().SetNComponents(1);
+            psData.SetSpectrum(newSpec[0], comp);
+            psData.GetArray(comp)->GetAxis().SetBinsRange(fFreqMin, fFreqMax, fEffectiveFreqBins);
+
+            if (i == 0)
+            {
+                KTINFO(speclog, "Set first spectrum object")
+
+                sliceHeader.SetIsNewAcquisition(1);
+                KTINFO(speclog, "Set New Acquisition!");
+
+                double min = psData.GetArray(comp)->GetAxis().GetRangeMin();
+                KTINFO(speclog, "First spectrum min freq = " << min);
+
+                double max = psData.GetArray(comp)->GetAxis().GetRangeMax();
+                KTINFO(speclog, "First spectrum max freq = " << max);
+
+                double width = psData.GetArray(comp)->GetAxis().GetBinWidth();
+                KTINFO(speclog, "First spectrum bin width = " << width);
+            }
+            else sliceHeader.SetIsNewAcquisition(0);
+
+            if(i == fNSpectra -1)
+            {
+                data->Of< Nymph::KTData >().SetLastData(true);
+                KTINFO(speclog, "fLastData set to TRUE");
+            }
+
+            fDataSignal(data);
+            if (i == 0) KTINFO(speclog, "First spectrum data signal output");
+        }
+
+        fSpecDoneSignal();
+        KTINFO(speclog, "Spec-done signal output");
+
+        for(unsigned j=0; j<nChannels;++j)
+            fSpecs[j].file.close();
+
         return true;
     }
 } /* namespace Katydid */

--- a/Source/IO/KTSpecProcessor.cc
+++ b/Source/IO/KTSpecProcessor.cc
@@ -13,7 +13,7 @@ using namespace std;
 
 namespace Katydid
 {
-    static Nymph::KTCommandLineOption< string > sFilenameCLO("Spec Processor", "Spec filename to open", "spec-file", 'c');
+    static Nymph::KTCommandLineOption< string > sFilenameCLO("Spec Processor", "Spec filename to open", "spec-file", 's');
 
     KTLOGGER(speclog, "KTSpecProcessor");
 
@@ -48,14 +48,7 @@ namespace Katydid
         // Config-file settings
         if (node != NULL)
         {
-            if (node->has("filename"))
-            {
-                KTDEBUG(speclog, "Adding single file to spec processor");
-                fFilenames.clear();
-                fFilenames.push_back( std::move(scarab::expand_path(node->get_value( "filename" ))) );
-                KTINFO(speclog, "Added file to spec processor: <" << fFilenames.back() << ">");
-            }
-            else if (node->has("filenames"))
+            if (node->has("filenames"))
             {
                 KTDEBUG(speclog, "Adding multiple files to spec processor");
                 fFilenames.clear();
@@ -66,14 +59,23 @@ namespace Katydid
                     KTINFO(speclog, "Added file to spec processor: <" << fFilenames.back() << ">");
                 }
             }
+            else if (node->has("filename"))
+            {
+                KTDEBUG(speclog, "Adding single file to spec processor");
+                fFilenames.clear();
+                fFilenames.push_back( std::move(scarab::expand_path(node->get_value( "filename" ))) );
+                KTINFO(speclog, "Added file to spec processor: <" << fFilenames.back() << ">");
+            }
 
             fNSpectra = node->get_value< unsigned >("spectra", fNSpectra);
+            KTINFO(speclog, "Number of spectra = " << fNSpectra);
             fPacketIDOffset = node->get_value< unsigned >("packet-ID-offset", fPacketIDOffset);
             fPacketHeaderSize = node->get_value< unsigned >("header-bytes", fPacketHeaderSize);
             fROACH_FFT_Avg = node->get_value< unsigned >("ROACH-spect-avg", fROACH_FFT_Avg);
             fFreqBins = node->get_value< unsigned >("freq-bins", fFreqBins); //total bins
             fFreqMin = node->get_value< double >("min-freq", fFreqMin);
             fFreqMax = node->get_value< double >("max-freq", fFreqMax);
+            KTINFO(speclog, "Maximum frequency = " << fFreqMax);
             fBinTOff = node->get_value< int >("TOff-bin", fBinTOff);
             fBinTOffPow = node->get_value< int >("TOff-bin-pow", fBinTOffPow);
             fSpecFreqAvg = node->get_value< unsigned >("freq-bin-avg", fSpecFreqAvg);
@@ -126,7 +128,7 @@ namespace Katydid
 
         const int nBins = fFreqBins / nChannels; // number of frequency bins per channel
         const int nPacketSize = fPacketHeaderSize + nBins; // could use reconfiguration (user config) if more general case wanted
-        KTDEBUG(speclog, "Packet Size: "<<nPacketSize);
+        KTINFO(speclog, "Packet Size: "<<nPacketSize);
 
         // For file j, j*fBinOffsetPerFile is added to the bin numbers to files are not "on top of each other"
         const unsigned fBinOffsetPerFile = fEffectiveFreqBins / nChannels;
@@ -161,13 +163,11 @@ namespace Katydid
         //loop over # of spectra to be read
         for(int i = 0; i < fNSpectra; ++i)
         {
-
             if (i == 0) KTINFO(speclog, "Preparing to read first spectrum");
 
             for(unsigned j = 0; j < nChannels; ++j)
             {
-                KTINFO(speclog, "Spec: "<<j<<" is at position: " << j * nPacketSize);
-                fSpecs[j].file.read(fSpecs[j].pointer, nPacketSize); //read full packet(s) into (respective) buffers
+                fSpecs[j].file.read(fSpecs[j].pointer, nPacketSize); //read full packet into buffer at position pointer
             }
 
             pkt_num[i] = PacketNumber(fSpecs[0].pointer);

--- a/Source/IO/KTSpecProcessor.cc
+++ b/Source/IO/KTSpecProcessor.cc
@@ -157,7 +157,7 @@ namespace Katydid
         std::fill(slice, slice + fEffectiveFreqBins, 0);
 
         vector <KTPowerSpectrum*> newSpec(1);
-        int pkt_num[fNSpectra];
+        vector<int> pkt_num(fNSpectra);
         unsigned binOffset;
 
         //loop over # of spectra to be read
@@ -229,11 +229,11 @@ namespace Katydid
             sliceHeader.SetBinWidth(fFreqMax/fEffectiveFreqBins);
 
             //assume for now that all runs start at time t=0
-            sliceHeader.SetTimeInRun(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
-            KTDEBUG(speclog, "TimeInRun = "<<(i*fFreqBins*fROACH_FFT_Avg/fFreqMax));
+            sliceHeader.SetTimeInRun(i/fFreqMax*fFreqBins*fROACH_FFT_Avg);
+            KTDEBUG(speclog, "TimeInRun = "<<(i/fFreqMax*fFreqBins*fROACH_FFT_Avg));
 
             //assume for now that there is 1 acq per run, all runs start at t=0
-            sliceHeader.SetTimeInAcq(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
+            sliceHeader.SetTimeInAcq(i/fFreqMax*fFreqBins*fROACH_FFT_Avg);
 
             sliceHeader.SetStartRecordNumber(0);
 

--- a/Source/IO/KTSpecProcessor.hh
+++ b/Source/IO/KTSpecProcessor.hh
@@ -43,7 +43,7 @@ namespace Katydid
         (\"filename\" will take priority over this)
 
      Command-line options defined
-     - -k (spec-file): spec filename to use
+     - -s (spec-file): spec filename to use
 
      Signals:
      - "header": void (Nymph::KTDataPtr) -- emitted when the header is parsed.

--- a/Source/IO/KTSpecProcessor.hh
+++ b/Source/IO/KTSpecProcessor.hh
@@ -1,22 +1,36 @@
-#ifndef KTEGGPROCESSOR_HH_
-#define KTEGGPROCESSOR_HH_
+#ifndef KTSPECPROCESSOR_HH_
+#define KTSPECPROCESSOR_HH_
 
 #include "KTPrimaryProcessor.hh"
 #include "KTData.hh"
-//#include "KTSpecHeader.hh"
 #include "KTSpecReader.hh"
 #include "KTSlot.hh"
 
 namespace Katydid
 {
 
+    class KTSpecHelper
+    {
+     // Micro-class to organize reading multiple spec files. Includes their buffers and keeps track of their pointers
+        public:
+            std::ifstream file;
+            std::vector<char> buffer;
+            char *pointer;
+            KTSpecHelper() {}
+            KTSpecHelper(boost::filesystem::path aFilename, const unsigned &aBufferSize):
+             file(aFilename.c_str(), std::ios::in|std::ios::binary),
+             buffer(aBufferSize),
+             pointer(buffer.data())
+            {}
+    };
+
     class KTPowerSpectrumData;
 
     /*!
      @class KTSpecProcessor
-     @author B. Graner
+     @author N. Buzinsky after H. Harrington after B. Graner
 
-     @brief reads a file with power spectrum data
+     @brief reads a file with compress power spectrum data
 
      Configuration name: "spec-processor"
 
@@ -29,7 +43,7 @@ namespace Katydid
         (\"filename\" will take priority over this)
 
      Command-line options defined
-     - -s (spec-file): spec filename to use
+     - -k (spec-file): spec filename to use
 
      Signals:
      - "header": void (Nymph::KTDataPtr) -- emitted when the header is parsed.
@@ -58,23 +72,28 @@ namespace Katydid
 
         private:
             int fNSpectra;
+            unsigned fPacketIDOffset; //where in the packet header is the packet ID [1,9], historically
             int fPacketHeaderSize;
-            int fSpectraAvg;
             int fFreqBins;
+            int fROACH_FFT_Avg;       //the number of sequential FFTs averaged on the DAQ before output to *.spec
+            int fSpecFreqAvg;         //the number of freq bins to average (for improving SNR with nonzero df/dt)
             double fFreqMin;
             double fFreqMax;
+            int fBinTOff;             //Bin where trap off signal should be found
+            int fBinTOffPow;
 
             Nymph::KTSignalData fDataSignal;
             Nymph::KTSignalOneArg< void > fSpecDoneSignal;
 
+            int PacketNumber(char *aBufferPointer);
 
+            std::vector<KTSpecHelper> fSpecs;
     };
 
     inline bool KTSpecProcessor::Run()
     {
         return ProcessSpec();
     }
-
 
 } /* namespace Katydid */
 

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -128,8 +128,21 @@ namespace Katydid
             return false;
         }
 
-        //vector<std::ifstream> files;
+        //check if fSpecFreqAvg divides fFreqBins evenly
+        if(fFreqBins % fSpecFreqAvg != 0)
+            KTWARN(specklog, "freq-bin-avg does not divide freq-bins!");
 
+        const unsigned fEffectiveFreqBins = fFreqBins / fSpecFreqAvg;
+
+        const int nChannels = fSpecks.size();
+        //check if fFreqBins divides nChannels evenly
+        if(fEffectiveFreqBins % nChannels != 0)
+            KTWARN(specklog, "nChannels does not divide (effective) freq-bins!");
+
+        // For file j, j*fBinOffsetPerFile is added to the bin numbers to files are not "on top of each other"
+        const unsigned fBinOffsetPerFile = fEffectiveFreqBins / nChannels;
+
+        // Open the .speck files
         for(unsigned i = 0; i <fFilenames.size(); ++i)
         {
             KTINFO(specklog, "Opening speck file <" << fFilenames[i] << ">");
@@ -147,20 +160,6 @@ namespace Katydid
                 KTINFO(specklog, "Speck file <" << fFilenames[i] << "> opened");
             }
         }
-
-        //check if fSpecFreqAvg divides fFreqBins evenly
-        if(fFreqBins % fSpecFreqAvg != 0)
-            KTWARN(specklog, "freq-bin-avg does not divide freq-bins!");
-
-        const unsigned fEffectiveFreqBins = fFreqBins / fSpecFreqAvg;
-
-        const int nChannels = fSpecks.size();
-        //check if fFreqBins divides nChannels evenly
-        if(fEffectiveFreqBins % nChannels != 0)
-            KTWARN(specklog, "nChannels does not divide (effective) freq-bins!");
-
-        // For file j, j*fBinOffsetPerFile is added to the bin numbers to files are not "on top of each other"
-        const unsigned fBinOffsetPerFile = fEffectiveFreqBins / nChannels;
 
         //spectra must be treated as unsigned 8-bit values (0-255)
         int slice[fEffectiveFreqBins]; //holder array for spectrum data, set to all zeros
@@ -314,12 +313,13 @@ namespace Katydid
 
             fDataSignal(data);
             if (i == 0) KTINFO(specklog, "First spectrum data signal output");
-
         }
+
         fSpeckDoneSignal();
         KTINFO(specklog, "Spec-done signal output");
 
-        //file.close();
+        for(unsigned j=0; j<nChannels;++j)
+            fSpecks[j].file.close();
 
         return true;
     }

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -23,15 +23,17 @@ namespace Katydid
             KTPrimaryProcessor(name),
             fProgressReportInterval(1),
             fFilenames(),
-            fFreqBins(4096),
+            fFreqBins(8192),
             fNSpectra(0),
+            fPacketIDOffset(9),
             fPacketHeaderSize(32),
             fFreqMin(0.),
-            fFreqMax(1600000000),
+            fFreqMax(2400000000),
             fBinTOff(342),          //the trap off signal frequency bin
             fBinTOffPow(20),
             fROACH_FFT_Avg(2),      //the number of sequential FFTs averaged on the DAQ before output to *.spec
             fSpecFreqAvg(1),        //the number of freq bins to average (for improving SNR with nonzero df/dt)
+            fSpecks(),
             fDataSignal("ps", this),
             fSpeckDoneSignal("spec-done", this)
     {
@@ -66,9 +68,10 @@ namespace Katydid
             }
 
             fNSpectra = node->get_value< unsigned >("spectra", fNSpectra);
+            fPacketIDOffset = node->get_value< unsigned >("packet-ID-offset", fPacketIDOffset);
             fPacketHeaderSize = node->get_value< unsigned >("header-bytes", fPacketHeaderSize);
             fROACH_FFT_Avg = node->get_value< unsigned >("ROACH-spect-avg", fROACH_FFT_Avg);
-            fFreqBins = node->get_value< unsigned >("freq-bins", fFreqBins);
+            fFreqBins = node->get_value< unsigned >("freq-bins", fFreqBins); //total bins
             fFreqMin = node->get_value< double >("min-freq", fFreqMin);
             fFreqMax = node->get_value< double >("max-freq", fFreqMax);
             fBinTOff = node->get_value< int >("TOff-bin", fBinTOff);
@@ -87,7 +90,8 @@ namespace Katydid
 
         return true;
     }
-    pair<unsigned, unsigned char> KTSpeckProcessor::read_high_power_point(char *aBuffer)
+
+    pair<unsigned, unsigned char> KTSpeckProcessor::ReadHighPowerPoint(char *aBuffer)
     {
         // returns (index, power) from byte data in file
         //aIndex (0 - 4095) is a 12-bit number, does not fit in a byte.
@@ -102,6 +106,14 @@ namespace Katydid
 
     }
 
+    int KTSpeckProcessor::PacketNumber(char *aBufferPointer)
+    {
+        int pkt_num = bitset<8>(uint8_t(*(aBufferPointer + fPacketIDOffset))).to_ulong() * pow(2,16);
+        pkt_num += bitset<8>(uint8_t(*(aBufferPointer + fPacketIDOffset + 1))).to_ulong() * pow(2,8);
+        pkt_num += bitset<8>(uint8_t(*(aBufferPointer + fPacketIDOffset + 2))).to_ulong();
+        return pkt_num;
+    }
+
     bool KTSpeckProcessor::ProcessSpeck()
     {
         if (fFilenames.size() == 0)
@@ -110,76 +122,103 @@ namespace Katydid
             return false;
         }
 
-        // open the file and load its contents into memblock
-        KTINFO(specklog, "Opening speck file <" << fFilenames[0] << ">");
-
-        if(fFilenames[0].extension() != ".speck")
+        if (fFilenames.size() > 2)
         {
-            KTFATAL(specklog, fFilenames[0] <<" is not a .speck file!");
+            KTERROR(specklog, "More than 2 speck simultaneous files have been specified! We don't have that much bandwidth!");
+            return false;
         }
 
-        std::ifstream file(fFilenames[0].c_str(), ios::in|ios::binary);
+        //vector<std::ifstream> files;
 
-        if (file.is_open())
+        for(unsigned i = 0; i <fFilenames.size(); ++i)
         {
-            KTINFO(specklog, "Speck file <" << fFilenames[0] << "> opened");
-            vector<char> buffer(std::istreambuf_iterator<char>(file), {}); //read full (compressed) file into unsigned char vector
-            unsigned nMaxBufferEntry = buffer.size();
+            KTINFO(specklog, "Opening speck file <" << fFilenames[i] << ">");
+            if(fFilenames[i].extension() != ".speck")
+                KTFATAL(specklog, fFilenames[i] <<" is not a .speck file!");
 
-            //check if fSpecFreqAvg divides fFreqBins evenly
-            if(fFreqBins % fSpecFreqAvg != 0)
-                KTWARN(specklog, "freq-bin-avg does not divide freq-bins!");
-
-            const unsigned fEffectiveFreqBins = fFreqBins / fSpecFreqAvg;
-
-            //spectra must be treated as unsigned 8-bit values (0-255)
-            int slice[fEffectiveFreqBins]; //holder array for spectrum data, set to all zeros
-            std::fill(slice, slice + fEffectiveFreqBins, 0);
-
-            int position = 0; //variable for read position start
-            unsigned numHighPowerPoints; //number of above threshold points per slice
-            pair<unsigned, unsigned char> highPowerBin; //index, power for above threshold points
-            vector<unsigned> nonZeroBins; //store above threshold bins, so that slice can be erased quickly
-
-            vector <KTPowerSpectrum*> newSpec(1);
-            int pkt_num [fNSpectra];
-
-            //loop over # of spectra to be read
-            for(int i = 0; i < fNSpectra; i++)
+            // open the file and load its full contents into memblock
+            fSpecks.emplace_back(fFilenames[i]);
+            if(!fSpecks[i].file.is_open())
             {
-                if (i == 0) KTINFO(specklog, "Preparing to read first spectrum");
-                KTINFO(specklog, "position = " << position);
+                KTFATAL(specklog, fFilenames[i] <<" is failed to open!");
+            }
+            else
+            {
+                KTINFO(specklog, "Speck file <" << fFilenames[i] << "> opened");
+            }
+        }
 
-                //Check if sequential spectra have correct packet numbers
-                pkt_num[i] = bitset<8>(uint8_t(buffer[position + 1])).to_ulong()*pow(2,16);
-                pkt_num[i] += bitset<8>(uint8_t(buffer[position + 2])).to_ulong()*pow(2,8);
-                pkt_num[i] += bitset<8>(uint8_t(buffer[position + 3])).to_ulong();
-                KTINFO(specklog, "Decimal pkt_num = " << pkt_num[i]);
-                if (i>0)
+        //check if fSpecFreqAvg divides fFreqBins evenly
+        if(fFreqBins % fSpecFreqAvg != 0)
+            KTWARN(specklog, "freq-bin-avg does not divide freq-bins!");
+
+        const unsigned fEffectiveFreqBins = fFreqBins / fSpecFreqAvg;
+
+        const int nChannels = fSpecks.size();
+        //check if fFreqBins divides nChannels evenly
+        if(fEffectiveFreqBins % nChannels != 0)
+            KTWARN(specklog, "nChannels does not divide (effective) freq-bins!");
+
+        // For file j, j*fBinOffsetPerFile is added to the bin numbers to files are not "on top of each other"
+        const unsigned fBinOffsetPerFile = fEffectiveFreqBins / nChannels;
+
+        //spectra must be treated as unsigned 8-bit values (0-255)
+        int slice[fEffectiveFreqBins]; //holder array for spectrum data, set to all zeros
+        std::fill(slice, slice + fEffectiveFreqBins, 0);
+
+        unsigned numHighPowerPoints; //number of above threshold points per slice
+        pair<unsigned, unsigned char> highPowerBin; //index, power for above threshold points
+        vector<unsigned> nonZeroBins; //store above threshold bins, so that slice can be erased quickly
+
+        vector <KTPowerSpectrum*> newSpec(1);
+        int pkt_num[fNSpectra];
+        unsigned binOffset, hpbIndex;
+
+        //loop over # of spectra to be read
+        for(int i = 0; i < fNSpectra; ++i)
+        {
+            if (i == 0) KTINFO(specklog, "Preparing to read first spectrum");
+
+            for(unsigned j = 0; j < nChannels; ++j)
+                KTINFO(specklog, "Speck: "<<j<<" is at position: " << fSpecks[j].position);
+
+            pkt_num[i] = PacketNumber(fSpecks[0].pointer);
+            KTINFO(specklog, "Decimal pkt_num = " << pkt_num[i]);
+
+            //Check if sequential spectra have correct packet numbers
+            if (i>0)
+            {
+                // Both fPacketsPerSpectrum and fSpecTimeAvg are forced to be 1, for now in speck_processor
+                int adjusted_pkt_num = (pkt_num[i-1] + 1) % 1048576; //2^20, max packet number for 2^12 bitcode
+                if(pkt_num[i] - adjusted_pkt_num != 0)
+                    KTWARN(specklog, "WARNING: " << pkt_num[i]-adjusted_pkt_num << " packets dropped!");
+            }
+            //Check if simultaneous spectra have correct packet numbers
+            if(nChannels == 2  && (pkt_num[i] != PacketNumber(fSpecks[1].pointer)))
+                KTFATAL(specklog, "You have packet shear between spectrogram  files! Incompatible files!");
+
+            // advance all speck objects past their headers
+            for(unsigned j = 0; j < nChannels; ++j)
+                fSpecks[j] += fPacketHeaderSize;
+
+            //reset all output spectrogram bins to zeros
+            for(unsigned j = 0; j < nonZeroBins.size(); ++j)
+                slice[nonZeroBins[j]] = 0;
+
+            nonZeroBins.clear();
+
+            //loop over sparse points in file, break when reading (0,0) - (end of slice marker)
+            numHighPowerPoints = 0;
+            for(unsigned j = 0; j < nChannels; ++j)
+            { 
+                binOffset = j*fBinOffsetPerFile;
+                while(fSpecks[j].position < fSpecks[j].nMaxBufferEntry)
                 {
-                    // Both fPacketsPerSpectrum and fSpecTimeAvg are forced to be 1, for now in speck_processor
-                    int adjusted_pkt_num = (pkt_num[i-1] + 1) % 1048576; //2^20, max packet number for 2^12 bitcode
-                    if(pkt_num[i] - adjusted_pkt_num != 0)
-                        KTWARN(specklog, "WARNING: " << pkt_num[i]-adjusted_pkt_num << " packets dropped!");
-                }
-
-                position += fPacketHeaderSize;
-
-                //reset all output spectrogram bins to zeros
-                for(unsigned j = 0; j < nonZeroBins.size(); ++j)
-                    slice[nonZeroBins[j]] = 0;
-
-                nonZeroBins.clear();
-
-                //loop over sparse points in file, break when reading (0,0) - (end of slice marker)
-                numHighPowerPoints = 0;
-                while(position < nMaxBufferEntry)
-                {
-                    highPowerBin = read_high_power_point(buffer.data() + position);
-                    position += 3; //2 bytes for 4096 bin number, 1 byte for power
-                    if(highPowerBin.first != 0 && highPowerBin.second !=0)
+                    highPowerBin = ReadHighPowerPoint(fSpecks[j].pointer);
+                    fSpecks[j] += 3; //2 bytes for 4096 bin number, 1 byte for power
+                    if(highPowerBin.first != 0 || highPowerBin.second !=0)
                     {
-                        unsigned hpbIndex = highPowerBin.first/fSpecFreqAvg;
+                        hpbIndex = highPowerBin.first/fSpecFreqAvg + binOffset;
                         slice[hpbIndex] += highPowerBin.second;
                         numHighPowerPoints += 1;
                         nonZeroBins.push_back(hpbIndex);
@@ -190,96 +229,98 @@ namespace Katydid
                         break;
                     }
                 }
-
-                unsigned comp = 0;
-                //initialize an object of type KTPowerSpectrum with all 0
-                //values and 8192 Bins from 0 to 1600 MHz
-                Nymph::KTDataPtr data(new Nymph::KTData());
-
-                KTSliceHeader& sliceHeader = data->Of< KTSliceHeader >().SetNComponents(1);
-
-                if (slice[fBinTOff] > fBinTOffPow)
-                {
-                    sliceHeader.SetIsTrapOff(1);
-                    //KTINFO(speclog, "Set trap off!");
-                }
-                else sliceHeader.SetIsTrapOff(0);
-
-                sliceHeader.SetSliceNumber(i);
-
-                sliceHeader.SetPacketNumber(pkt_num[i]);
-
-                //slice size in bytes = # of bins (given 8-bit resolution)
-                sliceHeader.SetRawSliceSize(numHighPowerPoints);
-
-                //no diff between 'raw' slice size, slice size
-                sliceHeader.SetSliceSize(fFreqBins);
-
-                //Nyquist frequency is 1/2 sampling rate
-                sliceHeader.SetSampleRate(2*fFreqMax);
-                KTINFO(specklog, "Frequency max = " << fFreqMax);
-
-                //slice length is 2x # of bins / 2x Nyquist freq, times averaged spectra
-                sliceHeader.SetSliceLength(fFreqBins*fROACH_FFT_Avg/fFreqMax);
-
-                //bin width = bandwidth/bins
-                sliceHeader.SetBinWidth(fFreqMax/fEffectiveFreqBins);
-
-                //assume for now that all runs start at time t=0
-                sliceHeader.SetTimeInRun(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
-                KTDEBUG(specklog, "TimeInRun = "<<(i*fFreqBins*fROACH_FFT_Avg/fFreqMax));
-
-                //assume for now that there is 1 acq per run, all runs start at t=0
-                sliceHeader.SetTimeInAcq(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
-
-                sliceHeader.SetStartRecordNumber(0);
-
-                sliceHeader.SetStartSampleNumber(0);
-
-                sliceHeader.SetEndRecordNumber(0);
-
-                sliceHeader.SetEndSampleNumber(0);
-
-                sliceHeader.SetRecordSize(0);
-
-
-                newSpec[0] = new KTPowerSpectrum(slice, fEffectiveFreqBins, fFreqMin, fFreqMax);
-                KTPowerSpectrumData& psData = data->Of< KTPowerSpectrumData >().SetNComponents(1);
-                psData.SetSpectrum(newSpec[0], comp);
-                psData.GetArray(comp)->GetAxis().SetBinsRange(fFreqMin, fFreqMax, fEffectiveFreqBins);
-
-                if (i == 0)
-                {
-                	KTINFO(specklog, "Set first spectrum object")
-                	
-                	sliceHeader.SetIsNewAcquisition(1);
-                    KTINFO(specklog, "Set New Acquisition!");
-                    
-                    double min = psData.GetArray(comp)->GetAxis().GetRangeMin();
-                    KTINFO(specklog, "First spectrum min freq = " << min);
-
-                    double max = psData.GetArray(comp)->GetAxis().GetRangeMax();
-                    KTINFO(specklog, "First spectrum max freq = " << max);
-
-                    double width = psData.GetArray(comp)->GetAxis().GetBinWidth();
-                    KTINFO(specklog, "First spectrum bin width = " << width);
-                }
-				else sliceHeader.SetIsNewAcquisition(0);
-
-                if(i == fNSpectra -1)
-                {
-                    data->Of< Nymph::KTData >().SetLastData(true);
-                    KTINFO(specklog, "fLastData set to TRUE");
-                }
-
-                fDataSignal(data);
-                if (i == 0) KTINFO(specklog, "First spectrum data signal output");
-
             }
-            fSpeckDoneSignal();
-            KTINFO(specklog, "Spec-done signal output");
+
+            unsigned comp = 0;
+            //initialize an object of type KTPowerSpectrum with all 0
+            //values and 8192 Bins from 0 to 1600 MHz
+            Nymph::KTDataPtr data(new Nymph::KTData());
+
+            KTSliceHeader& sliceHeader = data->Of< KTSliceHeader >().SetNComponents(1);
+
+            if (slice[fBinTOff] > fBinTOffPow)
+            {
+                sliceHeader.SetIsTrapOff(1);
+                //KTINFO(speclog, "Set trap off!");
+            }
+            else sliceHeader.SetIsTrapOff(0);
+
+            sliceHeader.SetSliceNumber(i);
+
+            sliceHeader.SetPacketNumber(pkt_num[i]);
+
+            //slice size in bytes = # of bins (given 8-bit resolution)
+            sliceHeader.SetRawSliceSize(numHighPowerPoints);
+
+            //no diff between 'raw' slice size, slice size
+            sliceHeader.SetSliceSize(fFreqBins);
+
+            //Nyquist frequency is 1/2 sampling rate
+            sliceHeader.SetSampleRate(2*fFreqMax);
+            KTINFO(specklog, "Frequency max = " << fFreqMax);
+
+            //slice length is 2x # of bins / 2x Nyquist freq, times averaged spectra
+            sliceHeader.SetSliceLength(fFreqBins*fROACH_FFT_Avg/fFreqMax);
+
+            //bin width = bandwidth/bins
+            sliceHeader.SetBinWidth(fFreqMax/fEffectiveFreqBins);
+
+            //assume for now that all runs start at time t=0
+            sliceHeader.SetTimeInRun(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
+            KTDEBUG(specklog, "TimeInRun = "<<(i*fFreqBins*fROACH_FFT_Avg/fFreqMax));
+
+            //assume for now that there is 1 acq per run, all runs start at t=0
+            sliceHeader.SetTimeInAcq(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
+
+            sliceHeader.SetStartRecordNumber(0);
+
+            sliceHeader.SetStartSampleNumber(0);
+
+            sliceHeader.SetEndRecordNumber(0);
+
+            sliceHeader.SetEndSampleNumber(0);
+
+            sliceHeader.SetRecordSize(0);
+
+
+            newSpec[0] = new KTPowerSpectrum(slice, fEffectiveFreqBins, fFreqMin, fFreqMax);
+            KTPowerSpectrumData& psData = data->Of< KTPowerSpectrumData >().SetNComponents(1);
+            psData.SetSpectrum(newSpec[0], comp);
+            psData.GetArray(comp)->GetAxis().SetBinsRange(fFreqMin, fFreqMax, fEffectiveFreqBins);
+
+            if (i == 0)
+            {
+                KTINFO(specklog, "Set first spectrum object")
+
+                sliceHeader.SetIsNewAcquisition(1);
+                KTINFO(specklog, "Set New Acquisition!");
+
+                double min = psData.GetArray(comp)->GetAxis().GetRangeMin();
+                KTINFO(specklog, "First spectrum min freq = " << min);
+
+                double max = psData.GetArray(comp)->GetAxis().GetRangeMax();
+                KTINFO(specklog, "First spectrum max freq = " << max);
+
+                double width = psData.GetArray(comp)->GetAxis().GetBinWidth();
+                KTINFO(specklog, "First spectrum bin width = " << width);
+            }
+            else sliceHeader.SetIsNewAcquisition(0);
+
+            if(i == fNSpectra -1)
+            {
+                data->Of< Nymph::KTData >().SetLastData(true);
+                KTINFO(specklog, "fLastData set to TRUE");
+            }
+
+            fDataSignal(data);
+            if (i == 0) KTINFO(specklog, "First spectrum data signal output");
+
         }
-        file.close();
+        fSpeckDoneSignal();
+        KTINFO(specklog, "Spec-done signal output");
+
+        //file.close();
+
         return true;
     }
 } /* namespace Katydid */

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -134,7 +134,7 @@ namespace Katydid
 
         const unsigned fEffectiveFreqBins = fFreqBins / fSpecFreqAvg;
 
-        const int nChannels = fSpecks.size();
+        const int nChannels = fFilenames.size();
         //check if fFreqBins divides nChannels evenly
         if(fEffectiveFreqBins % nChannels != 0)
             KTWARN(specklog, "nChannels does not divide (effective) freq-bins!");

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -30,7 +30,8 @@ namespace Katydid
             fFreqMax(1600000000),
             fBinTOff(342),          //the trap off signal frequency bin
             fBinTOffPow(20),
-            fSpectraAvg(2),
+            fROACH_FFT_Avg(2),      //the number of sequential FFTs averaged on the DAQ before output to *.spec
+            fSpecFreqAvg(1),        //the number of freq bins to average (for improving SNR with nonzero df/dt)
             fDataSignal("ps", this),
             fSpeckDoneSignal("spec-done", this)
     {
@@ -66,10 +67,13 @@ namespace Katydid
 
             fNSpectra = node->get_value< unsigned >("spectra", fNSpectra);
             fPacketHeaderSize = node->get_value< unsigned >("header-bytes", fPacketHeaderSize);
-            fSpectraAvg = node->get_value< unsigned >("ROACH-spect-avg", fSpectraAvg);
+            fROACH_FFT_Avg = node->get_value< unsigned >("ROACH-spect-avg", fROACH_FFT_Avg);
             fFreqBins = node->get_value< unsigned >("freq-bins", fFreqBins);
             fFreqMin = node->get_value< double >("min-freq", fFreqMin);
             fFreqMax = node->get_value< double >("max-freq", fFreqMax);
+            fBinTOff = node->get_value< int >("TOff-bin", fBinTOff);
+            fBinTOffPow = node->get_value< int >("TOff-bin-pow", fBinTOffPow);
+            fSpecFreqAvg = node->get_value< unsigned >("freq-bin-avg", fSpecFreqAvg);
         }
 
         // Command-line settings
@@ -122,9 +126,15 @@ namespace Katydid
             vector<char> buffer(std::istreambuf_iterator<char>(file), {}); //read full (compressed) file into unsigned char vector
             unsigned nMaxBufferEntry = buffer.size();
 
+            //check if fSpecFreqAvg divides fFreqBins evenly
+            if(fFreqBins % fSpecFreqAvg != 0)
+                KTWARN(specklog, "freq-bin-avg does not divide freq-bins!");
+
+            const unsigned fEffectiveFreqBins = fFreqBins / fSpecFreqAvg;
+
             //spectra must be treated as unsigned 8-bit values (0-255)
-            int slice[fFreqBins]; //holder array for spectrum data, set to all zeros
-            std::fill(slice, slice + fFreqBins, 0);
+            int slice[fEffectiveFreqBins]; //holder array for spectrum data, set to all zeros
+            std::fill(slice, slice + fEffectiveFreqBins, 0);
 
             int position = 0; //variable for read position start
             unsigned numHighPowerPoints; //number of above threshold points per slice
@@ -145,8 +155,12 @@ namespace Katydid
                 pkt_num[i] += bitset<8>(uint8_t(buffer[position + 2])).to_ulong()*pow(2,8);
                 pkt_num[i] += bitset<8>(uint8_t(buffer[position + 3])).to_ulong();
                 KTINFO(specklog, "Decimal pkt_num = " << pkt_num[i]);
-                if (i>0 && pkt_num[i]-pkt_num[i-1]!=1){
-                    KTWARN(specklog, "WARNING: " << pkt_num[i]-pkt_num[i-1] << " packets dropped!");
+                if (i>0)
+                {
+                    // Both fPacketsPerSpectrum and fSpecTimeAvg are forced to be 1, for now in speck_processor
+                    int adjusted_pkt_num = (pkt_num[i-1] + 1) % 1048576; //2^20, max packet number for 2^12 bitcode
+                    if(pkt_num[i] - adjusted_pkt_num != 0)
+                        KTWARN(specklog, "WARNING: " << pkt_num[i]-adjusted_pkt_num << " packets dropped!");
                 }
 
                 position += fPacketHeaderSize;
@@ -165,10 +179,11 @@ namespace Katydid
                     position += 3; //2 bytes for 4096 bin number, 1 byte for power
                     if(highPowerBin.first != 0 && highPowerBin.second !=0)
                     {
-                        slice[highPowerBin.first] = highPowerBin.second;
+                        unsigned hpbIndex = highPowerBin.first/fSpecFreqAvg;
+                        slice[hpbIndex] += highPowerBin.second;
                         numHighPowerPoints += 1;
-                        nonZeroBins.push_back(highPowerBin.first);
-                        KTDEBUG(specklog, "Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<int(highPowerBin.second));
+                        nonZeroBins.push_back(hpbIndex);
+                        KTDEBUG(specklog, "Adding high power point at slice: "<<i<<", bin: "<<hpbIndex<<", power: "<<int(highPowerBin.second));
                     }
                     else
                     {
@@ -205,17 +220,17 @@ namespace Katydid
                 KTINFO(specklog, "Frequency max = " << fFreqMax);
 
                 //slice length is 2x # of bins / 2x Nyquist freq, times averaged spectra
-                sliceHeader.SetSliceLength(fFreqBins*fSpectraAvg/fFreqMax);
+                sliceHeader.SetSliceLength(fFreqBins*fROACH_FFT_Avg/fFreqMax);
 
                 //bin width = bandwidth/bins
-                sliceHeader.SetBinWidth(fFreqMax/fFreqBins);
+                sliceHeader.SetBinWidth(fFreqMax/fEffectiveFreqBins);
 
                 //assume for now that all runs start at time t=0
-                sliceHeader.SetTimeInRun(i*fFreqBins*fSpectraAvg/fFreqMax);
-                KTDEBUG(specklog, "TimeInRun = "<<(i*fFreqBins*fSpectraAvg/fFreqMax));
+                sliceHeader.SetTimeInRun(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
+                KTDEBUG(specklog, "TimeInRun = "<<(i*fFreqBins*fROACH_FFT_Avg/fFreqMax));
 
                 //assume for now that there is 1 acq per run, all runs start at t=0
-                sliceHeader.SetTimeInAcq(i*fFreqBins*fSpectraAvg/fFreqMax);
+                sliceHeader.SetTimeInAcq(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
 
                 sliceHeader.SetStartRecordNumber(0);
 
@@ -228,10 +243,10 @@ namespace Katydid
                 sliceHeader.SetRecordSize(0);
 
 
-                newSpec[0] = new KTPowerSpectrum(slice, fFreqBins, fFreqMin, fFreqMax);
+                newSpec[0] = new KTPowerSpectrum(slice, fEffectiveFreqBins, fFreqMin, fFreqMax);
                 KTPowerSpectrumData& psData = data->Of< KTPowerSpectrumData >().SetNComponents(1);
                 psData.SetSpectrum(newSpec[0], comp);
-                psData.GetArray(comp)->GetAxis().SetBinsRange(fFreqMin, fFreqMax, fFreqBins);
+                psData.GetArray(comp)->GetAxis().SetBinsRange(fFreqMin, fFreqMax, fEffectiveFreqBins);
 
                 if (i == 0)
                 {

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -25,6 +25,7 @@ namespace Katydid
             fFilenames(),
             fFreqBins(4096),
             fNSpectra(0),
+            fPacketHeaderSize(32),
             fFreqMin(0.),
             fFreqMax(1600000000),
             fBinTOff(342),          //the trap off signal frequency bin
@@ -118,7 +119,7 @@ namespace Katydid
 
             //spectra must be treated as unsigned 8-bit values (0-255)
             int slice[fFreqBins]; //holder array for spectrum data, set to all zeros
-            memset(slice, 0, fFreqBins);
+            std::fill(slice, slice + fFreqBins, 0);
 
             int position = 0; //variable for read position start
             unsigned numHighPowerPoints; //number of above threshold points per slice
@@ -163,7 +164,7 @@ namespace Katydid
                         numHighPowerPoints += 1;
                         nonZeroBins.push_back(highPowerBin.first);
                         KTDEBUG(specklog, "Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<int(highPowerBin.second));
-                        //std::cout<<"Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<int(highPowerBin.second)<<std::endl;
+                        //std::cout<<"Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<slice[highPowerBin.first]<<std::endl;
                     }
                     else
                     {

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -170,7 +170,7 @@ namespace Katydid
         vector<unsigned> nonZeroBins; //store above threshold bins, so that slice can be erased quickly
 
         vector <KTPowerSpectrum*> newSpec(1);
-        int pkt_num[fNSpectra];
+        vector<int> pkt_num(fNSpectra);
         unsigned binOffset, hpbIndex;
 
         //loop over # of spectra to be read
@@ -265,11 +265,13 @@ namespace Katydid
             sliceHeader.SetBinWidth(fFreqMax/fEffectiveFreqBins);
 
             //assume for now that all runs start at time t=0
-            sliceHeader.SetTimeInRun(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
-            KTDEBUG(specklog, "TimeInRun = "<<(i*fFreqBins*fROACH_FFT_Avg/fFreqMax));
+            // be super careful about this. The product i*fFreqBins*fROACH_FFT_Avg exceeds the MAX_INT, causing overflow
+            // we switch to double be dividing immediately. Could go through intermediate of long ints
+            sliceHeader.SetTimeInRun(i/fFreqMax*fFreqBins*fROACH_FFT_Avg);
+            KTDEBUG(specklog, "TimeInRun = "<<(i/fFreqMax*fFreqBins*fROACH_FFT_Avg));
 
             //assume for now that there is 1 acq per run, all runs start at t=0
-            sliceHeader.SetTimeInAcq(i*fFreqBins*fROACH_FFT_Avg/fFreqMax);
+            sliceHeader.SetTimeInAcq(i/fFreqMax*fFreqBins*fROACH_FFT_Avg);
 
             sliceHeader.SetStartRecordNumber(0);
 

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -109,6 +109,11 @@ namespace Katydid
         // open the file and load its contents into memblock
         KTINFO(specklog, "Opening speck file <" << fFilenames[0] << ">");
 
+        if(fFilenames[0].extension() != ".speck")
+        {
+            KTFATAL(specklog, fFilenames[0] <<" is not a .speck file!");
+        }
+
         std::ifstream file(fFilenames[0].c_str(), ios::in|ios::binary);
 
         if (file.is_open())
@@ -164,7 +169,6 @@ namespace Katydid
                         numHighPowerPoints += 1;
                         nonZeroBins.push_back(highPowerBin.first);
                         KTDEBUG(specklog, "Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<int(highPowerBin.second));
-                        //std::cout<<"Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<slice[highPowerBin.first]<<std::endl;
                     }
                     else
                     {

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -1,6 +1,6 @@
-#include<iostream>
+#include <iostream>
 #include <fstream>
-#include "KTSpecProcessor.hh"
+#include "KTSpeckProcessor.hh"
 #include "KTCommandLineOption.hh"
 #include "KTData.hh"
 #include "KTSliceHeader.hh"
@@ -13,14 +13,13 @@ using namespace std;
 
 namespace Katydid
 {
-    static Nymph::KTCommandLineOption< string > sFilenameCLO("Spec Processor",
-    "Spec filename to open", "spec-file", 's');
+    static Nymph::KTCommandLineOption< string > sFilenameCLO("Speck Processor", "Speck filename to open", "speck-file", 'k');
 
-    KTLOGGER(speclog, "KTSpecProcessor");
+    KTLOGGER(specklog, "KTSpeckProcessor");
 
-    KT_REGISTER_PROCESSOR(KTSpecProcessor, "spec-processor");
+    KT_REGISTER_PROCESSOR(KTSpeckProcessor, "speck-processor");
 
-    KTSpecProcessor::KTSpecProcessor(const std::string& name) :
+    KTSpeckProcessor::KTSpeckProcessor(const std::string& name) :
             KTPrimaryProcessor(name),
             fProgressReportInterval(1),
             fFilenames(),
@@ -30,37 +29,38 @@ namespace Katydid
             fFreqMax(1600000000),
             fSpectraAvg(8),
             fDataSignal("ps", this),
-            fSpecDoneSignal("spec-done", this)
+            fSpeckDoneSignal("speck-done", this)
     {
     }
 
-    KTSpecProcessor::~KTSpecProcessor()
+    KTSpeckProcessor::~KTSpeckProcessor()
     {
     }
 
-    bool KTSpecProcessor::Configure(const scarab::param_node* node)
+    bool KTSpeckProcessor::Configure(const scarab::param_node* node)
     {
         // Config-file settings
         if (node != NULL)
         {
             if (node->has("filename"))
             {
-                KTDEBUG(speclog, "Adding single file to spec processor");
+                KTDEBUG(specklog, "Adding single file to speck processor");
                 fFilenames.clear();
                 fFilenames.push_back( std::move(scarab::expand_path(node->get_value( "filename" ))) );
-                KTINFO(speclog, "Added file to spec processor: <" << fFilenames.back() << ">");
+                KTINFO(specklog, "Added file to speck processor: <" << fFilenames.back() << ">");
             }
             else if (node->has("filenames"))
             {
-                KTDEBUG(speclog, "Adding multiple files to spec processor");
+                KTDEBUG(specklog, "Adding multiple files to speck processor");
                 fFilenames.clear();
                 const scarab::param_array* t_filenames = node->array_at("filenames");
                 for(scarab::param_array::const_iterator t_file_it = t_filenames->begin(); t_file_it != t_filenames->end(); ++t_file_it)
                 {
                     fFilenames.push_back( std::move(scarab::expand_path((*t_file_it)->as_value().as_string())) );
-                    KTINFO(speclog, "Added file to spec processor: <" << fFilenames.back() << ">");
+                    KTINFO(specklog, "Added file to speck processor: <" << fFilenames.back() << ">");
                 }
             }
+
             fNSpectra = node->get_value< unsigned >("spectra", fNSpectra);
             fPacketHeaderSize = node->get_value< unsigned >("header-bytes", fPacketHeaderSize);
             fSpectraAvg = node->get_value< unsigned >("ROACH-spect-avg", fSpectraAvg);
@@ -70,50 +70,55 @@ namespace Katydid
         }
 
         // Command-line settings
-        if (fCLHandler->IsCommandLineOptSet("spec-file"))
+        if (fCLHandler->IsCommandLineOptSet("speck-file"))
         {
-            KTDEBUG(speclog, "Adding single file to spec processor from the CL");
+            KTDEBUG(specklog, "Adding single file to speck processor from the CL");
             fFilenames.clear();
-            fFilenames.push_back( std::move(scarab::expand_path(fCLHandler->GetCommandLineValue< string >("spec-file"))));
-            KTINFO(speclog, "Added file to spec processor: <" << fFilenames.back() << ">");
+            fFilenames.push_back( std::move(scarab::expand_path(fCLHandler->GetCommandLineValue< string >("speck-file"))));
+            KTINFO(specklog, "Added file to speck processor: <" << fFilenames.back() << ">");
         }
 
         return true;
     }
+    std::pair<unsigned, char> KTSpeckProcessor::read_high_power_point(char *aBuffer)
+    {
+        // returns (index, power) from byte data in file
+        //aIndex (0 - 4095) is a 12-bit number, does not fit in a byte.
+        //Fit in 2 bytes via: index = 2^8 a[0] + a[1]
 
-    bool KTSpecProcessor::ProcessSpec()
+        uint8_t tens = *(aBuffer);
+        uint8_t ones = *(aBuffer + 1);
+        unsigned index = pow(2,8) * tens + ones;
+        char power = *(aBuffer + 2);
+
+        return std::pair<unsigned, char>(index, power);
+
+    }
+
+    bool KTSpeckProcessor::ProcessSpeck()
     {
         if (fFilenames.size() == 0)
         {
-            KTERROR(speclog, "No files have been specified");
+            KTERROR(specklog, "No files have been specified");
             return false;
         }
 
         // open the file and load its contents into memblock
-        KTINFO(speclog, "Opening spec file <" << fFilenames[0] << ">");
-        streampos size;
-        unsigned char * memblock;
+        KTINFO(specklog, "Opening speck file <" << fFilenames[0] << ">");
 
-        std::ifstream file(fFilenames[0].c_str(), ios::in|ios::binary|ios::ate);
+        std::ifstream file(fFilenames[0].c_str(), ios::in|ios::binary);
 
         if (file.is_open())
         {
-            KTINFO(speclog, "Spec file <" << fFilenames[0] << "> opened");
-            unsigned char a;
-            //uint a; //spectra must be treated as unsigned 8-bit values (0-255)
+            KTINFO(specklog, "Speck file <" << fFilenames[0] << "> opened");
+            vector<char> buffer(std::istreambuf_iterator<char>(file), {}); //read full (compressed) file into unsigned char vector
+            unsigned nMaxBufferEntry = buffer.size();
+
+            //spectra must be treated as unsigned 8-bit values (0-255)
             int slice[fFreqBins]; //holder array for spectrum data
             int position = 0; //variable for read position start
-            int blockSize = fPacketHeaderSize+fFreqBins; //add header length
-
-            //declare array of 1-byte chars to read from binary file
-            char memblock [blockSize];
-            char headerblock [fPacketHeaderSize]; //declare array to read header of 1st packet in file
-            
-            //The header of each packet is divided into 4 words of 64 bits (8 bytes) each.
-            //Information on the packet offset is located in the first 3 bits of the final word.
-            //The 0th bit of the last word should always be 1 to indicate freq-domain data.
-            //Bits 1 and 2 of the last word indicate which part of the spectrum a packet
-            //corresponds to. All trailing bits should be zero.
+            unsigned numHighPowerPoints; //number of above threshold points per slice
+            std::pair<unsigned, char> highPowerBin; //index, power for above threshold points
 
             vector <KTPowerSpectrum*> newSpec(1);
             int pkt_num [fNSpectra];
@@ -121,26 +126,39 @@ namespace Katydid
             //loop over # of spectra to be read
             for(int i = 0; i < fNSpectra; i++)
             {
-                if (i == 0) KTINFO(speclog, "Preparing to read first spectrum");
-                position = i*(blockSize);
-                KTINFO(speclog, "position = " << position);
-                file.seekg (position, ios::beg); //set read pointer location
-                file.read (headerblock, fPacketHeaderSize); //read header first
+                if (i == 0) KTINFO(specklog, "Preparing to read first spectrum");
+                KTINFO(specklog, "position = " << position);
 
                 //Check if sequential spectra have correct packet numbers
-                pkt_num[i] =bitset<8>(memblock[1]).to_ulong()*pow(2,16)+bitset<8>(memblock[2]).to_ulong()*pow(2,8)+bitset<8>(memblock[3]).to_ulong();
-                KTINFO(speclog, "Decimal pkt_num = " << pkt_num[i]);
+                pkt_num[i] = bitset<8>(uint8_t(buffer[position + 1])).to_ulong()*pow(2,16);
+                pkt_num[i] += bitset<8>(uint8_t(buffer[position + 2])).to_ulong()*pow(2,8);
+                pkt_num[i] += bitset<8>(uint8_t(buffer[position + 3])).to_ulong();
+                KTINFO(specklog, "Decimal pkt_num = " << pkt_num[i]);
                 if (i>0 && pkt_num[i]-pkt_num[i-1]!=1){
-                    KTWARN(speclog, "WARNING: " << pkt_num[i]-pkt_num[i-1] << " packets dropped!");
+                    KTWARN(specklog, "WARNING: " << pkt_num[i]-pkt_num[i-1] << " packets dropped!");
                 }
 
-                file.seekg (position, ios::beg); //set read pointer location
-                file.read (memblock, blockSize); //read 1 spectrum of data
+                position += fPacketHeaderSize;
 
-                for (int x = 0; x < fFreqBins; x++)
+                //reset all output spectrogram bins to zeros
+                memset(slice, 0, fFreqBins);
+
+                //loop over sparse points in file, break when reading (0,0) - (end of slice marker)
+                numHighPowerPoints = 0;
+                while(position < nMaxBufferEntry)
                 {
-                    a =  memblock[x+fPacketHeaderSize];
-                    slice[x] = a;
+                    highPowerBin = read_high_power_point(buffer.data() + position);
+                    position += 3; //2 bytes for 4096 bin number, 1 byte for power
+                    if(highPowerBin.first != 0 && highPowerBin.second !=0)
+                    {
+                        slice[highPowerBin.first] = highPowerBin.second;
+                        numHighPowerPoints += 1;
+                        KTDEBUG(specklog, "Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<highPowerBin.second);
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
 
                 unsigned comp = 0;
@@ -155,14 +173,14 @@ namespace Katydid
                 sliceHeader.SetPacketNumber(pkt_num[i]);
 
                 //slice size in bytes = # of bins (given 8-bit resolution)
-                sliceHeader.SetRawSliceSize(fFreqBins);
+                sliceHeader.SetRawSliceSize(numHighPowerPoints);
 
                 //no diff between 'raw' slice size, slice size
                 sliceHeader.SetSliceSize(fFreqBins);
 
                 //Nyquist frequency is 1/2 sampling rate
                 sliceHeader.SetSampleRate(2*fFreqMax);
-                KTINFO(speclog, "Frequency max = " << fFreqMax);
+                KTINFO(specklog, "Frequency max = " << fFreqMax);
 
                 //slice length is 2x # of bins / 2x Nyquist freq, times averaged spectra
                 sliceHeader.SetSliceLength(fFreqBins*fSpectraAvg/fFreqMax);
@@ -172,7 +190,7 @@ namespace Katydid
 
                 //assume for now that all runs start at time t=0
                 sliceHeader.SetTimeInRun(i*fFreqBins*fSpectraAvg/fFreqMax);
-                KTDEBUG(speclog, "TimeInRun = "<<(i*fFreqBins*fSpectraAvg/fFreqMax));
+                KTDEBUG(specklog, "TimeInRun = "<<(i*fFreqBins*fSpectraAvg/fFreqMax));
 
                 //assume for now that there is 1 acq per run, all runs start at t=0
                 sliceHeader.SetTimeInAcq(i*fFreqBins*fSpectraAvg/fFreqMax);
@@ -195,34 +213,34 @@ namespace Katydid
 
                 if (i == 0)
                 {
-                	KTINFO(speclog, "Set first spectrum object")
+                	KTINFO(specklog, "Set first spectrum object")
                 	
                 	sliceHeader.SetIsNewAcquisition(1);
-                    KTINFO(speclog, "Set New Acquisition!");
+                    KTINFO(specklog, "Set New Acquisition!");
                     
                     double min = psData.GetArray(comp)->GetAxis().GetRangeMin();
-                    KTINFO(speclog, "First spectrum min freq = " << min);
+                    KTINFO(specklog, "First spectrum min freq = " << min);
 
                     double max = psData.GetArray(comp)->GetAxis().GetRangeMax();
-                    KTINFO(speclog, "First spectrum max freq = " << max);
+                    KTINFO(specklog, "First spectrum max freq = " << max);
 
                     double width = psData.GetArray(comp)->GetAxis().GetBinWidth();
-                    KTINFO(speclog, "First spectrum bin width = " << width);
+                    KTINFO(specklog, "First spectrum bin width = " << width);
                 }
 				else sliceHeader.SetIsNewAcquisition(0);
 
                 if(i == fNSpectra -1)
                 {
                     data->Of< Nymph::KTData >().SetLastData(true);
-                    KTINFO(speclog, "fLastData set to TRUE");
+                    KTINFO(specklog, "fLastData set to TRUE");
                 }
 
                 fDataSignal(data);
-                if (i == 0) KTINFO(speclog, "First spectrum data signal output");
+                if (i == 0) KTINFO(specklog, "First spectrum data signal output");
 
             }
-            fSpecDoneSignal();
-            KTINFO(speclog, "Spec-done signal output");
+            fSpeckDoneSignal();
+            KTINFO(specklog, "Speck-done signal output");
         }
         file.close();
         return true;

--- a/Source/IO/KTSpeckProcessor.cc
+++ b/Source/IO/KTSpeckProcessor.cc
@@ -27,9 +27,11 @@ namespace Katydid
             fNSpectra(0),
             fFreqMin(0.),
             fFreqMax(1600000000),
-            fSpectraAvg(8),
+            fBinTOff(342),          //the trap off signal frequency bin
+            fBinTOffPow(20),
+            fSpectraAvg(2),
             fDataSignal("ps", this),
-            fSpeckDoneSignal("speck-done", this)
+            fSpeckDoneSignal("spec-done", this)
     {
     }
 
@@ -80,7 +82,7 @@ namespace Katydid
 
         return true;
     }
-    std::pair<unsigned, char> KTSpeckProcessor::read_high_power_point(char *aBuffer)
+    pair<unsigned, unsigned char> KTSpeckProcessor::read_high_power_point(char *aBuffer)
     {
         // returns (index, power) from byte data in file
         //aIndex (0 - 4095) is a 12-bit number, does not fit in a byte.
@@ -91,7 +93,7 @@ namespace Katydid
         unsigned index = pow(2,8) * tens + ones;
         char power = *(aBuffer + 2);
 
-        return std::pair<unsigned, char>(index, power);
+        return pair<unsigned, unsigned char>(index, power);
 
     }
 
@@ -115,10 +117,13 @@ namespace Katydid
             unsigned nMaxBufferEntry = buffer.size();
 
             //spectra must be treated as unsigned 8-bit values (0-255)
-            int slice[fFreqBins]; //holder array for spectrum data
+            int slice[fFreqBins]; //holder array for spectrum data, set to all zeros
+            memset(slice, 0, fFreqBins);
+
             int position = 0; //variable for read position start
             unsigned numHighPowerPoints; //number of above threshold points per slice
-            std::pair<unsigned, char> highPowerBin; //index, power for above threshold points
+            pair<unsigned, unsigned char> highPowerBin; //index, power for above threshold points
+            vector<unsigned> nonZeroBins; //store above threshold bins, so that slice can be erased quickly
 
             vector <KTPowerSpectrum*> newSpec(1);
             int pkt_num [fNSpectra];
@@ -141,7 +146,10 @@ namespace Katydid
                 position += fPacketHeaderSize;
 
                 //reset all output spectrogram bins to zeros
-                memset(slice, 0, fFreqBins);
+                for(unsigned j = 0; j < nonZeroBins.size(); ++j)
+                    slice[nonZeroBins[j]] = 0;
+
+                nonZeroBins.clear();
 
                 //loop over sparse points in file, break when reading (0,0) - (end of slice marker)
                 numHighPowerPoints = 0;
@@ -153,7 +161,9 @@ namespace Katydid
                     {
                         slice[highPowerBin.first] = highPowerBin.second;
                         numHighPowerPoints += 1;
-                        KTDEBUG(specklog, "Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<highPowerBin.second);
+                        nonZeroBins.push_back(highPowerBin.first);
+                        KTDEBUG(specklog, "Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<int(highPowerBin.second));
+                        //std::cout<<"Adding high power point at slice: "<<i<<", bin: "<<highPowerBin.first<<", power: "<<int(highPowerBin.second)<<std::endl;
                     }
                     else
                     {
@@ -167,6 +177,13 @@ namespace Katydid
                 Nymph::KTDataPtr data(new Nymph::KTData());
 
                 KTSliceHeader& sliceHeader = data->Of< KTSliceHeader >().SetNComponents(1);
+
+                if (slice[fBinTOff] > fBinTOffPow)
+                {
+                    sliceHeader.SetIsTrapOff(1);
+                    //KTINFO(speclog, "Set trap off!");
+                }
+                else sliceHeader.SetIsTrapOff(0);
 
                 sliceHeader.SetSliceNumber(i);
 
@@ -240,7 +257,7 @@ namespace Katydid
 
             }
             fSpeckDoneSignal();
-            KTINFO(specklog, "Speck-done signal output");
+            KTINFO(specklog, "Spec-done signal output");
         }
         file.close();
         return true;

--- a/Source/IO/KTSpeckProcessor.hh
+++ b/Source/IO/KTSpeckProcessor.hh
@@ -9,6 +9,26 @@
 namespace Katydid
 {
 
+    class KTSpeckHelper
+    {
+     // Micro-class to organize reading multiple speck files. Includes their buffers and keeps track of their pointers
+        public:
+            std::ifstream file;
+            std::vector<char> buffer;
+            unsigned nMaxBufferEntry;
+            char *pointer;
+            unsigned position;
+            KTSpeckHelper() {}
+            KTSpeckHelper(boost::filesystem::path aFilename):
+             file(aFilename.c_str(), std::ios::in|std::ios::binary),
+             buffer(std::istreambuf_iterator<char>(file), {}), //read full (compressed) file into unsigned char vector
+             nMaxBufferEntry(buffer.size()),
+             pointer(buffer.data()),
+             position(0)
+            {}
+            KTSpeckHelper& operator+=(int aAdvance) { position += aAdvance; pointer += aAdvance; return *this;} //overload += operator to advance buffer pointer
+    };
+
     class KTPowerSpectrumData;
 
     /*!
@@ -57,6 +77,7 @@ namespace Katydid
 
         private:
             int fNSpectra;
+            unsigned fPacketIDOffset; //where in the packet header is the packet ID [1,9], historically
             int fPacketHeaderSize;
             int fFreqBins;
             int fROACH_FFT_Avg;       //the number of sequential FFTs averaged on the DAQ before output to *.spec
@@ -69,17 +90,16 @@ namespace Katydid
             Nymph::KTSignalData fDataSignal;
             Nymph::KTSignalOneArg< void > fSpeckDoneSignal;
 
-            std::pair<unsigned, unsigned char> read_high_power_point(char *aBuffer);
+            std::pair<unsigned, unsigned char> ReadHighPowerPoint(char *aBuffer);
+            int PacketNumber(char *aBufferPointer);
 
-
+            std::vector<KTSpeckHelper> fSpecks;
     };
 
     inline bool KTSpeckProcessor::Run()
     {
         return ProcessSpeck();
     }
-
-
 
 } /* namespace Katydid */
 

--- a/Source/IO/KTSpeckProcessor.hh
+++ b/Source/IO/KTSpeckProcessor.hh
@@ -1,0 +1,83 @@
+#ifndef KTEGGPROCESSOR_HH_
+#define KTEGGPROCESSOR_HH_
+
+#include "KTPrimaryProcessor.hh"
+#include "KTData.hh"
+#include "KTSpecReader.hh"
+#include "KTSlot.hh"
+
+namespace Katydid
+{
+
+    class KTPowerSpectrumData;
+
+    /*!
+     @class KTSpeckProcessor
+     @author N. Buzinsky after B. Graner
+
+     @brief reads a file with compress power spectrum data
+
+     Configuration name: "speck-processor"
+
+     Available configuration options:
+     - "progress-report-interval": unsigned -- Interval (# of slices) between
+        reports (mainly relevant for RELEASE builds); turn off by setting to 0
+     - "filename": string -- Speck filename to use
+        (will take priority over \"filenames\")
+     - "filenames": array of strings -- Speck filenames to use
+        (\"filename\" will take priority over this)
+
+     Command-line options defined
+     - -k (speck-file): speck filename to use
+
+     Signals:
+     - "header": void (Nymph::KTDataPtr) -- emitted when the header is parsed.
+     - "psd": void (Nymph::KTDataPtr) -- emitted when the new power spectrum is
+        produced; Guarantees KTPowerSpectrumData
+     - "spec-done": void () --  emitted when a file is finished.
+     - "summary": void (const KTProcSummary*) -- emitted when a file is
+        finished (after "spec-done")
+
+    */
+    class KTSpeckProcessor : public Nymph::KTPrimaryProcessor
+    {
+        public:
+            KTSpeckProcessor(const std::string& name = "speck-processor");
+            virtual ~KTSpeckProcessor();
+
+            bool Configure(const scarab::param_node* node);
+
+            bool Run();
+
+            bool ProcessSpeck();
+
+            MEMBERVARIABLE(unsigned, ProgressReportInterval);
+
+            MEMBERVARIABLEREF(KTSpecReader::path_vec, Filenames);
+
+        private:
+            int fNSpectra;
+            int fPacketHeaderSize;
+            int fSpectraAvg;
+            int fFreqBins;
+            double fFreqMin;
+            double fFreqMax;
+
+            Nymph::KTSignalData fDataSignal;
+            Nymph::KTSignalOneArg< void > fSpeckDoneSignal;
+
+            std::pair<unsigned, char> read_high_power_point(char *aBuffer);
+
+
+    };
+
+    inline bool KTSpeckProcessor::Run()
+    {
+        return ProcessSpeck();
+    }
+
+
+
+} /* namespace Katydid */
+
+#endif /* KTSPECPROCESSOR_HH_ */

--- a/Source/IO/KTSpeckProcessor.hh
+++ b/Source/IO/KTSpeckProcessor.hh
@@ -58,8 +58,9 @@ namespace Katydid
         private:
             int fNSpectra;
             int fPacketHeaderSize;
-            int fSpectraAvg;
             int fFreqBins;
+            int fROACH_FFT_Avg;       //the number of sequential FFTs averaged on the DAQ before output to *.spec
+            int fSpecFreqAvg;         //the number of freq bins to average (for improving SNR with nonzero df/dt)
             double fFreqMin;
             double fFreqMax;
             int fBinTOff;             //Bin where trap off signal should be found

--- a/Source/IO/KTSpeckProcessor.hh
+++ b/Source/IO/KTSpeckProcessor.hh
@@ -62,11 +62,13 @@ namespace Katydid
             int fFreqBins;
             double fFreqMin;
             double fFreqMax;
+            int fBinTOff;             //Bin where trap off signal should be found
+            int fBinTOffPow;
 
             Nymph::KTSignalData fDataSignal;
             Nymph::KTSignalOneArg< void > fSpeckDoneSignal;
 
-            std::pair<unsigned, char> read_high_power_point(char *aBuffer);
+            std::pair<unsigned, unsigned char> read_high_power_point(char *aBuffer);
 
 
     };

--- a/Source/IO/KTSpeckProcessor.hh
+++ b/Source/IO/KTSpeckProcessor.hh
@@ -1,5 +1,5 @@
-#ifndef KTEGGPROCESSOR_HH_
-#define KTEGGPROCESSOR_HH_
+#ifndef KTSPECKPROCESSOR_HH_
+#define KTSPECKPROCESSOR_HH_
 
 #include "KTPrimaryProcessor.hh"
 #include "KTData.hh"
@@ -82,4 +82,4 @@ namespace Katydid
 
 } /* namespace Katydid */
 
-#endif /* KTSPECPROCESSOR_HH_ */
+#endif /* KTSPECKPROCESSOR_HH_ */


### PR DESCRIPTION
Seems to work, in that it is printing out the correct high power bins, producing sensible track segments

Download data from this DAQ test: https://docs.google.com/document/d/1tSXIeRM3BcXMRS208RdlFI2aivg6MCaBS7x4IsaZoJ0/edit#heading=h.v4krbduoceqm
We use

Noise baseline: RID 1109 **(acq = 1)**
Spec (Vaunix On): RID 1114 (acq = 0)
Speck (Vaunix On): RID 1117 (acq = 0)
(Filenames are already set, just make them available)


Both vaunix runs are at 10^10 slope. Not sure if the DB scan radius is set correctly
For the zero-suppressed code, I needed to lower the threshold on the discriminator to see anything. Makes sense that it wouldn't necessarily be the same

My laptop crashes if I try to run the full second. Could just be a local issue. 

Memory requirements should be ~2x bigger than before
Sometimes I just have to call the Katydid command twice for it to "do" anything. Hoping it is just my local machine + config settings that are needed to finalize this

Configs are attached

[configs.zip](https://github.com/Helium6CRES/katydid/files/14390960/configs.zip)
