### PR TITLE
replace return with break

### DIFF
--- a/Source/Data/EventAnalysis/KTLongTrackData.cc
+++ b/Source/Data/EventAnalysis/KTLongTrackData.cc
@@ -345,7 +345,7 @@ namespace Katydid
             double f_mid = f(mid);
 
             if (std::abs(f_mid) < tol)
-                return mid;
+                break;
 
             if (f_lo * f_mid < 0)
                 lambda_hi = mid;


### PR DESCRIPTION
returning mid directly returns λ, not λ/2 as if it were to reach the end of the loop. Isn't returning the correct root of the function f(λ)

This condition always occurs, unless we have a max SNR event (λ = 60, λ/2 = 30)